### PR TITLE
Wrap gemm for dense matrices. Remove gemv wrapper because gemm covers

### DIFF
--- a/src/Elemental.jl
+++ b/src/Elemental.jl
@@ -3,7 +3,7 @@ module Elemental
 using MPI
 using DistributedArrays
 
-import Base: A_mul_B!, copy, copy!, similar, size
+import Base: A_mul_B!, copy, copy!, print, similar, size
 
 include("../deps/deps.jl")
 
@@ -45,6 +45,7 @@ include("distmatrix.jl")
 include("distsparsematrix.jl")
 include("distmultivec.jl")
 include("matrices.jl")
+include("io.jl")
 include("blas_like/level1.jl")
 include("blas_like/level2.jl")
 include("blas_like/level3.jl")

--- a/src/blas_like/level3.jl
+++ b/src/blas_like/level3.jl
@@ -2,13 +2,24 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                            (:Float64, :Float64, :d),
                            (:Complex64, :Float32, :c),
                            (:Complex128, :Float64, :z))
-    @eval begin
-        function A_mul_B!(α::$elty, A::DistSparseMatrix{$elty}, x::DistMultiVec{$elty}, β::$elty, y::DistMultiVec{$elty})
-            err = ccall(($(string("ElMultiplyDist_", ext)), libEl), Cuint,
-                (Cint, $elty, Ptr{Void}, Ptr{Void}, $elty, Ptr{Void}),
-                EL_NORMAL, α, A.obj, x.obj, β, y.obj)
-            err == 0 || throw(ElError(err))
-            return y
+
+    for (mat, sym) in ((:Matrix, "_"),
+                       (:DistMatrix, "Dist_"))
+
+        for (transA, elenumA) in (("", :EL_NORMAL), ("t", :EL_TRANSPOSE), ("c", :EL_ADJOINT))
+            for (transB, elenumB) in (("", :EL_NORMAL), ("t", :EL_TRANSPOSE), ("c", :EL_ADJOINT))
+                f = symbol("A", transA, "_mul_B", transB, "!")
+
+                @eval begin
+                    function ($f)(α::$elty, A::$mat{$elty}, B::$mat{$elty}, β::$elty, C::$mat{$elty})
+                        err = ccall(($(string("ElGemm", sym, ext)), libEl), Cuint,
+                            (Cint, Cint, $elty, Ptr{Void}, Ptr{Void}, $elty, Ptr{Void}),
+                            $elenumA, $elenumB, α, A.obj, B.obj, β, C.obj)
+                        err == 0 || throw(ElError(err))
+                        return C
+                    end
+                end
+            end
         end
     end
 end

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,14 @@
+for (elty, ext) in ((:Float32, :s),
+                    (:Float64, :d),
+                    (:Complex64, :c),
+                    (:Complex128, :z))
+
+    @eval begin
+        function print(A::DistMatrix{$elty}, title::ASCIIString)
+            err = ccall(($(string("ElPrintDist_", ext)), libEl), Cuint,
+                (Ptr{Void}, Ptr{UInt8}),
+                A.obj, title)
+            err == 0 || throw(ElError(err))
+        end
+    end
+end

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -33,3 +33,15 @@ function RegSolveCtrl{T<:ElFloatType}(::Type{T};
         ElBool(progress),
         ElBool(time))
 end
+
+for (ext, elty) in (("_s", :Float32), ("_d", :Float64), ("_c", :Complex64), ("_z", :Complex128))
+    @eval begin
+        function svdvals(A::DistMatrix{$elty})
+            s = DistMatrix($elty)
+            ccall(($(string("ElSingularValues", ext)), libEl), Void,
+                (Ptr{Void}, Ptr{Void}),
+                A.obj, s.obj)
+            return s
+        end
+    end
+end

--- a/test/lav.jl
+++ b/test/lav.jl
@@ -6,7 +6,7 @@ using MPI
 n0 = 50
 n1 = 50
 testNative = true
-display = true
+display = false
 worldRank = MPI.Comm_rank(MPI.COMM_WORLD)
 worldSize = MPI.Comm_size(MPI.COMM_WORLD)
 if worldRank == 0
@@ -27,7 +27,7 @@ function stackedFD2D(n0, n1)
     height = 2*n0*n1
     width = n0*n1
     A = El.DistSparseMatrix(Float64, height, width)
-    @show localHeight = El.localHeight(A)
+    localHeight = El.localHeight(A)
     El.reserve(A, 6*localHeight)
 
     for sLoc in 1:localHeight
@@ -88,9 +88,9 @@ AWidth = El.width(A)
 bHeight = El.height(b)
 bWidth = El.width(b)
 
-# if display
-    # show(IO, A)
-# end
+if display
+    show(IO, A)
+end
 ctrl = El.LPAffineCtrl(Float64,
             mehrotraCtrl = El.MehrotraCtrl(Float64,
                             solveCtrl = El.RegSolveCtrl(Float64, progress = true),
@@ -98,7 +98,7 @@ ctrl = El.LPAffineCtrl(Float64,
                             outerEquil = true,
                             time = true))
 
-# elapsedLAV = @elapsed x = El.lav(A, b)
+elapsedLAV = @elapsed x = El.lav(A, b)
 elapsedLAV = @elapsed x = El.lav(A, b, ctrl)
 
 if MPI.Comm_rank(MPI.COMM_WORLD) == 0
@@ -128,8 +128,9 @@ end
 
 rLS = copy(b)
 A_mul_B!(-1.0, A, xLS, 1., rLS)
-# if display
-    # El.Display( rLS, "A x_{LS} - b" )
+if display
+    El.Display( rLS, "A x_{LS} - b" )
+end
 
 rLSTwoNorm = El.nrm2(rLS)
 rLSOneNorm = El.entrywiseNorm(rLS, 1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,15 +10,9 @@ function runtests()
     print_with_color(:white, "Running Elemental.jl tests\n")
     for f in testfiles
         try
-            if success(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
-                Base.with_output_color(:green,STDOUT) do io
-                    println(io,"\tSUCCESS: $f")
-                end
-            else
-                Base.with_output_color(:red,STDERR) do io
-                    println("\tFAILED: $f")
-                end
-                nfail += 1
+            run(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
+            Base.with_output_color(:green,STDOUT) do io
+                println(io,"\tSUCCESS: $f")
             end
         catch ex
             Base.with_output_color(:red,STDERR) do io


### PR DESCRIPTION
the same functionality. Move Distributed sparse gemv to blas2.jl. Also add print method for `DistMatrix`