### PR TITLE
Update structs to changes in Elemental to make Travis lights green

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,24 @@
 language: julia
+
 os:
   - linux
+
 julia:
   - nightly
+
 notifications:
   email: false
+
 before_install:
   - sudo add-apt-repository -y ppa:staticfloat/julia-deps
   - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
   - sudo apt-get update -qq -y
   - curl http://www.cmake.org/files/v3.2/cmake-3.2.1-Linux-x86_64.tar.gz | sudo tar -x -z --strip-components 1 -C /usr
-  - sudo apt-get install -qq -y gfortran mpich2 libmpich2-3 libmpich2-dev clang
-  - export CC=clang
-  - export CXX=clang++
+  - sudo apt-get install -qq -y gfortran mpich2 libmpich2-3 libmpich2-dev gcc-4.9 g++-4.9 gfortran-4.9 libstdc++-4.9-dev
+  - export CC=gcc-4.9
+  - export CXX=g++-4.9
+  - export CPU_CORES=2
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone("MPI"); Pkg.build("MPI")'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.4-
 MPI
+DistributedArrays

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -44,6 +44,6 @@ cd(builddir) do
                -D EL_BLAS_SUFFIX=$blas_suffix
                -D EL_LAPACK_SUFFIX=$blas_suffix
                $srcdir`)
-    run(`make -j $CPU_CORES`)
+    run(`make -j 2`)
     run(`make install`)
 end

--- a/deps/deps.jl
+++ b/deps/deps.jl
@@ -28,7 +28,8 @@ macro checked_lib(lib)
         const $(esc(lib)) = $libpath
     end
 end
-#@checked_lib_opt libmetis
-#@checked_lib_opt libparmetis
-#@checked_lib_opt libpmrrr
+@checked_lib_opt libmetis
+@checked_lib_opt libparmetis
+@checked_lib_opt libElSuiteSparse
+@checked_lib_opt libpmrrr
 @checked_lib libEl

--- a/src/blas_like/level3.jl
+++ b/src/blas_like/level3.jl
@@ -4,7 +4,7 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                            (:Complex128, :Float64, :z))
     @eval begin
         function A_mul_B!(α::$elty, A::DistSparseMatrix{$elty}, x::DistMultiVec{$elty}, β::$elty, y::DistMultiVec{$elty})
-            err = ccall(($(string("ElSparseMultiplyDist_", ext)), libEl), Cuint,
+            err = ccall(($(string("ElMultiplyDist_", ext)), libEl), Cuint,
                 (Cint, $elty, Ptr{Void}, Ptr{Void}, $elty, Ptr{Void}),
                 EL_NORMAL, α, A.obj, x.obj, β, y.obj)
             err == 0 || throw(ElError(err))

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -1,31 +1,35 @@
-const EL_REG_REFINE_FGMRES = Cuint(0)
-const EL_REG_REFINE_LGMRES = Cuint(1)
-const EL_REG_REFINE_IR = Cuint(2)
-const EL_REG_REFINE_IR_MOD = Cuint(3)
+typealias RegSolveAlg Cuint
 
-immutable RegQSDCtrl{T<:ElFloatType}
-    regPrimal::T
-    regDual::T
-    alg::Cuint
+const REG_SOLVE_FGMRES = RegSolveAlg(0)
+const REG_SOLVE_LGMRES = RegSolveAlg(1)
+
+immutable RegSolveCtrl{T<:ElFloatType}
+    alg::RegSolveAlg
     relTol::T
     relTolRefine::T
+    maxIts::ElInt
     maxRefineIts::ElInt
     restart::ElInt
     progress::ElBool
     time::ElBool
 end
-function RegQSDCtrl{T<:ElFloatType}(::Type{T};
-                    regPrimal=eps(T)^convert(T, 0.5),
-                    regDual=eps(T)^convert(T, 0.5),
-                    alg=EL_REG_REFINE_FGMRES,
-                    relTol=eps(T)^convert(T, 0.5),
-                    relTolRefine=eps(T)^convert(T, 0.5),
-                    maxRefineIts=50,
-                    restart=10,
-                    progress::Bool=false,
-                    time::Bool=false)
-    RegQSDCtrl{T}(regPrimal, regDual, alg,
-                  relTol, relTolRefine,
-                  maxRefineIts, restart,
-                  ElBool(progress),ElBool(time))
+
+function RegSolveCtrl{T<:ElFloatType}(::Type{T};
+                    alg = REG_SOLVE_FGMRES,
+                    relTol = eps(T)^0.5,
+                    relTolRefine = eps(T)^0.8,
+                    maxIts = 4,
+                    maxRefineIts = 2,
+                    restart = 4,
+                    progress = false,
+                    time = false)
+
+    RegSolveCtrl{T}(RegSolveAlg(alg),
+        T(relTol),
+        T(relTolRefine),
+        ElInt(maxIts),
+        ElInt(maxRefineIts),
+        ElInt(restart),
+        ElBool(progress),
+        ElBool(time))
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -31,13 +31,11 @@ function ElBoolType()
     #       to improperly passed structs to Elemental's C interface. This is
     #       worth investigating and might be an alignment issue.
 
-    warn("Hardcoding ElBool to Cint")
-    #boolsize = Ref(zero(Cuint))
-    #err = ccall((:ElSizeOfCBool, libEl), Cuint, (Ref{Cuint},), boolsize)
-    #err == 0 || throw(ElError(err))
-    #return boolsize[] == 1 ? Uint8 : Cint
-
-    return Cint
+    # warn("Hardcoding ElBool to Cint")
+    boolsize = Ref(zero(Cuint))
+    err = ccall((:ElSizeOfCBool, libEl), Cuint, (Ref{Cuint},), boolsize)
+    err == 0 || throw(ElError(err))
+    return boolsize[] == 1 ? UInt8 : Cint
 end
 const ElBool = ElBoolType()
 
@@ -49,7 +47,7 @@ function ElBool(value::Bool)
     end
 end
 
-typealias ElFloatType Union(Float32,Float64)
+typealias ElFloatType Union{Float32,Float64}
 
 abstract ElementalMatrix{T} <: AbstractMatrix{T}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,13 @@ using Base.Test
 function runtests()
     nprocs = min(4, CPU_CORES)
     exename = joinpath(JULIA_HOME, Base.julia_exename())
-    testfiles = sort(filter(x->x!="runtests.jl", readdir(dirname(@__FILE__))))
+    testdir = dirname(@__FILE__)
+    testfiles = sort(filter(x->x!="runtests.jl", readdir(testdir)))
     nfail = 0
     print_with_color(:white, "Running Elemental.jl tests\n")
     for f in testfiles
         try
-            if success(`mpirun -np $nprocs $exename $f`)
+            if success(`mpirun -np $nprocs $exename $(joinpath(testdir, f))`)
                 Base.with_output_color(:green,STDOUT) do io
                     println(io,"\tSUCCESS: $f")
                 end


### PR DESCRIPTION
Update to DistMultiply -> Multiply change

Revert change of ElBool initialization

REQUIRE Distributed Arrays

Revert comment out explicit library loading

And use GCC bacuse I think it uses less memory and is therefore not getting killed by Travis. Also restrict to two workers for the same reason.