### PR TITLE
Add the remaning methods necessary for sparse TSVD

### DIFF
--- a/src/lapack_like/props.jl
+++ b/src/lapack_like/props.jl
@@ -24,24 +24,18 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                 return rval[]
             end
 
-            function maxNorm(A::$mat{$elty})
+            function infinityNorm(A::$mat{$elty})
                 rval = Ref{$relty}(0)
-                err = ccall(($(string("ElMaxNorm", sym, ext)), libEl), Cuint,
+                err = ccall(($(string("ElInfinityNorm", sym, ext)), libEl), Cuint,
                     (Ptr{Void}, Ref{$relty}),
                     A.obj, rval)
                 err == 0 || throw(ElError(err))
                 return rval[]
             end
-        end
-    end
 
-    for (mat, sym) in ((:Matrix, "_"),
-                       (:DistMatrix, "Dist_"))
-        @eval begin
-
-            function infinityNorm(A::$mat{$elty})
+            function maxNorm(A::$mat{$elty})
                 rval = Ref{$relty}(0)
-                err = ccall(($(string("ElInfinityNorm", sym, ext)), libEl), Cuint,
+                err = ccall(($(string("ElMaxNorm", sym, ext)), libEl), Cuint,
                     (Ptr{Void}, Ref{$relty}),
                     A.obj, rval)
                 err == 0 || throw(ElError(err))
@@ -56,6 +50,12 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                 err == 0 || throw(ElError(err))
                 return rval[]
             end
+        end
+    end
+
+    for (mat, sym) in ((:Matrix, "_"),
+                       (:DistMatrix, "Dist_"))
+        @eval begin
 
             function safeHPDDeterminant(uplo::UpperOrLower, A::$mat{$elty})
                 rval = Ref{SafeProduct{$relty}}()

--- a/src/matrices.jl
+++ b/src/matrices.jl
@@ -82,7 +82,7 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                        (:DistSparseMatrix, "DistSparse_"))
         @eval begin
             # Helmholtz
-            function helmholtz!(A::$mat{$elty}, nx::Integer, shift::Number)
+            function helmholtz!(A::$mat{$elty}, nx::Integer; shift::Number = 0)
                 err = ccall(($(string("ElHelmholtz1D", sym, ext)), libEl), Cuint,
                     (Ptr{Void}, ElInt, $elty),
                     A.obj, nx, shift)
@@ -90,7 +90,7 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                 return A
             end
 
-            function helmholtz!(A::$mat{$elty}, nx::Integer, ny::Integer, shift::Number)
+            function helmholtz!(A::$mat{$elty}, nx::Integer, ny::Integer; shift::Number = 0)
                 err = ccall(($(string("ElHelmholtz2D", sym, ext)), libEl), Cuint,
                     (Ptr{Void}, ElInt, ElInt, $elty),
                     A.obj, nx, ny, shift)
@@ -98,7 +98,7 @@ for (elty, relty, ext) in ((:Float32, :Float32, :s),
                 return A
             end
 
-            function helmholtz!(A::$mat{$elty}, nx::Integer, ny::Integer, nz::Integer, shift::Number)
+            function helmholtz!(A::$mat{$elty}, nx::Integer, ny::Integer, nz::Integer; shift::Number = 0)
                 err = ccall(($(string("ElHelmholtz3D", sym, ext)), libEl), Cuint,
                     (Ptr{Void}, ElInt, ElInt, ElInt, $elty),
                     A.obj, nx, ny, nz, shift)


### PR DESCRIPTION
```jl
julia> using MPI

julia> man = MPIManager(np = 4);

julia> addprocs(man);

julia> @mpi_do man A = Elemental.DistSparseMatrix(Float64)

julia> using Elemental

julia> @everywhere using TSVD

julia> @mpi_do man A = Elemental.DistSparseMatrix(Float64)

julia> @mpi_do man Elemental.helmholtz!(A, 50, 50, 50)

julia> @time @mpi_do man F = tsvd(A)
  8.091107 seconds (2.85 k allocations: 217.391 KB)

julia> @mpi_do man println(F[2])
        From worker 4:  [31182.400548235677]
        From worker 2:  [31182.400548235677]
        From worker 3:  [31182.400548235677]
        From worker 5:  [31182.400548235677]
```