### PR TITLE
Prepare for upcoming deletion of Base.Git module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os:
 
 julia:
   - 0.4
+  - 0.5
   - nightly
 
 env:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
 Compat
 DistributedArrays 0.2.0
+Git

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,4 +1,4 @@
-const Git = Base.Git
+import Git
 
 # Use this version of Elemental
 Elsha = "79987d38b04838acf6b6195be1967177521ee908"


### PR DESCRIPTION
https://github.com/JuliaPackaging/Git.jl should be essentially equivalent, but will also ensure that you have git installed on platforms where it knows how to get a binary. If you already have git on your system path it'll just use it.