### PR TITLE
update libelemental to v0.87.7

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,7 +1,7 @@
 import Libdl, LibGit2, LinearAlgebra
 
-# Use this version of Elemental
-Elsha = "79987d38b04838acf6b6195be1967177521ee908"
+# Use Elemental version 0.87.7
+Elsha = "477e503a7a840cc1a75173552711b980505a0b06"
 
 if Sys.iswindows()
     error("Elemental only works on Unix Platforms")
@@ -49,6 +49,7 @@ cd(builddir) do
                -D MATH_LIBS=$mathlib
                -D EL_BLAS_SUFFIX=$blas_suffix
                -D EL_LAPACK_SUFFIX=$blas_suffix
+               -D CMAKE_INSTALL_LIBDIR=$prefix/lib
                -D CMAKE_INSTALL_RPATH=$prefix/lib
                $srcdir`)
     run(`make -j $build_procs`)


### PR DESCRIPTION
`pkg> build Elemental` currently fails on my system because cmake can't find `mpi.h`. So i tried updating to v0.87.7 in order to get this patch: https://github.com/elemental/Elemental/commit/0c38ca4b9960df448765ed28800e3cc21dc14cc6.

The build then succeeds, but there are some test failures:

<details>
<summary>Test log</summary>

```
(v1.1) pkg> test Elemental
   Testing Elemental
 Resolving package versions...
 Installed Compat ──── v1.5.0
 Installed BinDeps ─── v0.8.10
 Installed URIParser ─ v0.4.0
 Installed MPI ─────── v0.7.2
  Building MPI → `~/.julia/packages/MPI/U5ujD/deps/build.log`
    Status `/tmp/tmpjv2UdV/Manifest.toml`
  [9e28174c] BinDeps v0.8.10
  [34da2185] Compat v1.5.0
  [aaf54ef3] DistributedArrays v0.6.0
  [902c3f28] Elemental v0.4.0+ #update-to-0.87.7 (https://github.com/nolta/Elemental.jl)
  [da04e1cc] MPI v0.7.2
  [27ebfcd6] Primes v0.4.0
  [30578b45] URIParser v0.4.0
  [2a0f44e3] Base64  [`@stdlib/Base64`]
  [ade2ca70] Dates  [`@stdlib/Dates`]
  [8bb1440f] DelimitedFiles  [`@stdlib/DelimitedFiles`]
  [8ba89e20] Distributed  [`@stdlib/Distributed`]
  [b77e0a4c] InteractiveUtils  [`@stdlib/InteractiveUtils`]
  [76f85450] LibGit2  [`@stdlib/LibGit2`]
  [8f399da3] Libdl  [`@stdlib/Libdl`]
  [37e2e46d] LinearAlgebra  [`@stdlib/LinearAlgebra`]
  [56ddb016] Logging  [`@stdlib/Logging`]
  [d6f4376e] Markdown  [`@stdlib/Markdown`]
  [a63ad114] Mmap  [`@stdlib/Mmap`]
  [44cfe95a] Pkg  [`@stdlib/Pkg`]
  [de0858da] Printf  [`@stdlib/Printf`]
  [3fa0cd96] REPL  [`@stdlib/REPL`]
  [9a3f8284] Random  [`@stdlib/Random`]
  [ea8e919c] SHA  [`@stdlib/SHA`]
  [9e88b42a] Serialization  [`@stdlib/Serialization`]
  [1a1011a3] SharedArrays  [`@stdlib/SharedArrays`]
  [6462fe0b] Sockets  [`@stdlib/Sockets`]
  [2f01184e] SparseArrays  [`@stdlib/SparseArrays`]
  [10745b16] Statistics  [`@stdlib/Statistics`]
  [8dfed614] Test  [`@stdlib/Test`]
  [cf7118a7] UUIDs  [`@stdlib/UUIDs`]
  [4ec0a83e] Unicode  [`@stdlib/Unicode`]
[ Info: Running Elemental.jl tests
WARNING: could not import Broadcast._max into DistributedArrays
WARNING: could not import Broadcast._max into DistributedArrays
WARNING: could not import Broadcast._max into DistributedArrays
WARNING: could not import Broadcast._max into DistributedArrays
worldSize=4
RuizEquil: 0.00237202 secs
|| A ||_2 estimate: 2.87098
|| G ||_2 estimate: 1
|| b ||_2 = 70.9243
|| c ||_2 = 100
|| h ||_2 = 0
Imbalance factor of A: 1.00015
Imbalance factor of G: 1
Imbalance factor of J: 1.42773
ND: 0.075484 secs
Uncaught exception
Uncaught exception
Uncaught exception
Uncaught exception
Uncaught exception
Uncaught exception
Uncaught exception
Uncaught exception
Process Process 3 caught error message:
1 caught error message:
Matrix was singular
Matrix was singular
Process 0 caught error message:
Process 2 caught error message:
Matrix was singular
Matrix was singular
ERROR: ERROR: ERROR: ERROR: LoadError: LoadError: LoadError: LoadError: Elemental.RuntimeError()Elemental.RuntimeError()
Stacktrace:
Stacktrace:Elemental.RuntimeError()Elemental.RuntimeError()
 [1] 
Stacktrace:
Stacktrace:
 [1] 
 [1] 
 [1] ElErrorElErrorElErrorElError((::::((::::UInt32) at /home/nolta/.julia/packages/Elemental/RhZjb/src/error.jl:20
 [2] lav! at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:18 [inlined]
 [3] lav(::Elemental.DistSparseMatrix{Float64}, ::Elemental.DistMultiVec{Float64}, ::Elemental.LPAffineCtrl{Float64}) at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:42
 [4] top-level scope at util.jl:213
 [5] include at ./boot.jl:326 [inlined]
 [6] include_relative(::Module, ::String) at ./loading.jl:1038
 [7] include(::Module, ::String) at ./sysimg.jl:29
 [8] exec_options(::Base.JLOptions) at ./client.jl:267
 [9] _start() at ./client.jl:436
in expression starting at /home/nolta/.julia/packages/Elemental/RhZjb/test/lav.jl:101
UInt32) at /home/nolta/.julia/packages/Elemental/RhZjb/src/error.jl:20
 [2] lav! at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:18 [inlined]
 [3] lav(::Elemental.DistSparseMatrix{Float64}, ::Elemental.DistMultiVec{Float64}, ::Elemental.LPAffineCtrl{Float64}) at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:42
 [4] top-level scope at util.jl:213
 [5] include at ./boot.jl:326 [inlined]
 [6] include_relative(::Module, ::String) at ./loading.jl:1038
 [7] include(::Module, ::String) at ./sysimg.jl:29
 [8] exec_options(::Base.JLOptions) at ./client.jl:267
 [9] _start() at ./client.jl:436
in expression starting at /home/nolta/.julia/packages/Elemental/RhZjb/test/lav.jl:101
UInt32) at /home/nolta/.julia/packages/Elemental/RhZjb/src/error.jl:20
 [2] UInt32) at /home/nolta/.julia/packages/Elemental/RhZjb/src/error.jl:20
 [2] lav! at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:18 [inlined]
 [3] lav(::Elemental.DistSparseMatrix{Float64}, ::Elemental.DistMultiVec{Float64}, ::Elemental.LPAffineCtrl{Float64}) at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:42
 [4] top-level scope at util.jl:213
 [5] include at ./boot.jl:326 [inlined]
 [6] include_relative(::Module, ::String) at ./loading.jl:1038
 [7] include(::Module, ::String) at ./sysimg.jl:29
 [8] exec_options(::Base.JLOptions) at ./client.jl:267
 [9] _start() at ./client.jl:436
in expression starting at /home/nolta/.julia/packages/Elemental/RhZjb/test/lav.jl:101
lav! at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:18 [inlined]
 [3] lav(::Elemental.DistSparseMatrix{Float64}, ::Elemental.DistMultiVec{Float64}, ::Elemental.LPAffineCtrl{Float64}) at /home/nolta/.julia/packages/Elemental/RhZjb/src/optimization/models.jl:42
 [4] top-level scope at util.jl:213
 [5] include at ./boot.jl:326 [inlined]
 [6] include_relative(::Module, ::String) at ./loading.jl:1038
 [7] include(::Module, ::String) at ./sysimg.jl:29
 [8] exec_options(::Base.JLOptions) at ./client.jl:267
 [9] _start() at ./client.jl:436
in expression starting at /home/nolta/.julia/packages/Elemental/RhZjb/test/lav.jl:101
-------------------------------------------------------
Primary job  terminated normally, but 1 process returned
a non-zero exit code. Per user-direction, the job has been aborted.
-------------------------------------------------------
--------------------------------------------------------------------------
mpirun detected that one or more processes exited with non-zero status, thus causing
the job to be terminated. The first process to do so was:

  Process name: [[32444,1],0]
  Exit code:    1
--------------------------------------------------------------------------
    Error: lav.jl
failed process: Process(`mpirun -np 4 /opt/julia/1.1.0/bin/julia -Cnative -J/opt/julia/1.1.0/lib/julia/sys.so --check-bounds=yes -g1 /home/nolta/.julia/packages/Elemental/RhZjb/test/lav.jl`, ProcessExited(1)) [1]
Stacktrace:
 [1] (::getfield(Main, Symbol("##4#6")){ErrorException})(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}) at /home/nolta/.julia/packages/Elemental/RhZjb/test/runtests.jl:18
 [2] #with_output_color#671(::Bool, ::Function, ::Function, ::Symbol, ::Base.TTY) at ./util.jl:366
 [3] with_output_color(::Function, ::Symbol, ::Base.TTY) at ./util.jl:364
 [4] runtests_mpirun() at /home/nolta/.julia/packages/Elemental/RhZjb/test/runtests.jl:16
 [5] runtests() at /home/nolta/.julia/packages/Elemental/RhZjb/test/runtests.jl:54
 [6] top-level scope at none:0
 [7] include at ./boot.jl:326 [inlined]
 [8] include_relative(::Module, ::String) at ./loading.jl:1038
 [9] include(::Module, ::String) at ./sysimg.jl:29
 [10] include(::String) at ./client.jl:403
 [11] top-level scope at none:0
 [12] eval(::Module, ::Any) at ./boot.jl:328
 [13] exec_options(::Base.JLOptions) at ./client.jl:243
 [14] _start() at ./client.jl:436LAV time: 7.82026896 seconds
|| b ||_2       = 22.679091300663472
|| b ||_oo      = 3.1967628924418032
|| A x - b ||_2 = 20.309621224048957
|| A x - b ||_1 = 246.52560797114376
LS time: 0.050256287 seconds
|| A x_{LS} - b ||_2 = 16.327279920442386
|| A x_{LS} - b ||_1 = 293.4495907781675
    SUCCESS: lavdense.jl
    SUCCESS: matrix.jl
    SUCCESS: distmatrix.jl
    SUCCESS: props.jl
    SUCCESS: generic.jl
Test Summary:                                    | Pass  Test Summary:                                    | Pass  Test Summary:                                    | Pass  Total
Total
Total
generel eigenvalues (Schur) with eltype: Float32 |    1  generel eigenvalues (Schur) with eltype: Float32 |    1  generel eigenvalues (Schur) with eltype: Float32 |    1      1
    1
    1
Test Summary:                                    | Pass  Total
generel eigenvalues (Schur) with eltype: Float32 |    1      1
Test Summary:                                    | Pass  Total
generel eigenvalues (Schur) with eltype: Float64 |    1      1
Test Summary:                                    | Pass  Total
generel eigenvalues (Schur) with eltype: Float64 |    1      1
Test Summary:                                    | Pass  Total
generel eigenvalues (Schur) with eltype: Float64 |    1      1
Test Summary:                                    | Pass  Total
generel eigenvalues (Schur) with eltype: Float64 |    1      1
Test Summary:                                             | Test Summary:                                             | Test Summary:                                             | Pass  Pass  Total
generel eigenvalues (Schur) with eltype: Complex{Float32} | Pass  Total
Total
generel eigenvalues (Schur) with eltype: Complex{Float32} |    1     1      1
generel eigenvalues (Schur) with eltype: Complex{Float32} |    1      1    1

Test Summary:                                             | Pass  Total
generel eigenvalues (Schur) with eltype: Complex{Float32} |    1      1
Test Summary:                                             | Test Summary:                                             | Test Summary:                                             | Pass  Pass  Pass  TotalTotal
Total

generel eigenvalues (Schur) with eltype: Complex{Float64} | generel eigenvalues (Schur) with eltype: Complex{Float64} |    1  generel eigenvalues (Schur) with eltype: Complex{Float64} |    1     1      1
    1
Test Summary:                                             |     1
Pass  Total
generel eigenvalues (Schur) with eltype: Complex{Float64} |    1      1
    SUCCESS: spectral.jl
[ Info: Running Elemental.jl tests
WARNING: eval into closed module Base:
Expr(:block, #= Symbol("/home/nolta/.julia/packages/Compat/hsya0/src/Compat.jl"):1891 =#, Expr(:call, :range, Expr(:parameters, Expr(:..., :kwargs)), :start, :stop) = Expr(:block, #= Symbol("/home/nolta/.julia/packages/Compat/hsya0/src/Compat.jl"):1891 =#, Expr(:call, :range, Expr(:parameters, Expr(:kw, :stop, :stop), Expr(:..., :kwargs)), :start)))
  ** incremental compilation may be broken for this module **

WARNING: Method definition range(Any, Any) in module Base at range.jl:90 overwritten at /home/nolta/.julia/packages/Compat/hsya0/src/Compat.jl:1891.
WARNING: Method definition #range(Any, typeof(Base.range), Any, Any) in module Base overwritten.
    SUCCESS: darray.jl
   Testing Elemental tests passed
```

</details>