### PR TITLE
Precompile Elemental before running in parallel

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using DistributedArrays
 using TSVD
 using Primes
 using MPIClusterManagers
+using Elemental
 
 function runtests_mpirun()
     nprocs = min(4, Sys.CPU_THREADS)


### PR DESCRIPTION
It looks like there are some problems with precompilation and the caching on Travis and since precompilation likely slows down CI anyway, I'm here disabling it. Hopefully, it should get rid of failures like https://travis-ci.org/github/JuliaParallel/Elemental.jl/jobs/696457942