### PR TITLE
Expose common factorisations

### DIFF
--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -222,3 +222,19 @@ function hcat(x::Vector{DistMatrix{T}}) where {T}
         return A
     end
 end
+
+import DistributedArrays.localpart
+# used in testing
+function localpart(A::Elemental.DistMatrix{T}) where T
+  buffer = Base.zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
+  return localpart!(buffer, A)
+end
+
+function localpart!(buffer, A::Elemental.DistMatrix)
+  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
+  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
+    buffer[i, j] = Elemental.getLocal(A, i, j)
+  end
+  return buffer
+end
+

--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -226,24 +226,24 @@ end
 import DistributedArrays.localpart
 # used in testing
 function localpart(A::Elemental.DistMatrix{T}) where T
-  buffer = Base.zeros(T, localHeight(A), localWidth(A))
-  return localpart!(buffer, A)
+    buffer = Base.zeros(T, localHeight(A), localWidth(A))
+    return localpart!(buffer, A)
 end
 
 function localpart!(buffer, A::Elemental.DistMatrix)
-  @assert size(buffer) == (localHeight(A), localWidth(A))
-  for j in 1:localWidth(A), i in 1:localHeight(A)
-    buffer[i, j] = getLocal(A, i, j)
-  end
-  return buffer
+    @assert size(buffer) == (localHeight(A), localWidth(A))
+    for j in 1:localWidth(A), i in 1:localHeight(A)
+        buffer[i, j] = getLocal(A, i, j)
+    end
+    return buffer
 end
 
 import DistributedArrays.localindices
 # used in testing
 function localindices(A::Elemental.DistMatrix{T}) where T
-  # sometimes they aren't contigous so cant do start:start+length
-  rows = findall(isLocalRow(A, i) for i in 1:height(A))
-  cols = findall(isLocalCol(A, i) for i in 1:width(A))
-  return (rows, cols)
+    # sometimes they aren't contigous so cant do start:start+length
+    rows = findall(isLocalRow(A, i) for i in 1:height(A))
+    cols = findall(isLocalCol(A, i) for i in 1:width(A))
+    return (rows, cols)
 end
 

--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -148,7 +148,7 @@ for (elty, ext) in ((:ElInt, :i),
                 A.obj, i, j))
             return A
         end
-        
+
         function isLocalRow(A::DistMatrix{$elty}, i::Integer)
             rv = Ref{ElInt}(0)
             ElError(ccall(($(string("ElDistMatrixIsLocalRow_", ext)), libEl), Cuint,

--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -165,30 +165,6 @@ for (elty, ext) in ((:ElInt, :i),
             return Bool(rv[])
         end
 
-        function owner(A::DistMatrix{$elty})
-            rv = Ref{ElInt}(0)
-            ElError(ccall(($(string("ElDistMatrixRowOwner_", ext)), libEl), Cuint,
-                (Ptr{Cvoid}, Ref{ElInt}),
-                A.obj, rv))
-            return rv[]
-        end
-
-        function rowOwner(A::DistMatrix{$elty}, i::Integer)
-            rv = Ref{ElInt}(0)
-            ElError(ccall(($(string("ElDistMatrixRowOwner_", ext)), libEl), Cuint,
-                (Ptr{Cvoid}, ElInt, Ref{ElInt}),
-                A.obj, i - 1, rv))
-            return rv[]
-        end
-
-        function colOwner(A::DistMatrix{$elty}, i::Integer)
-            rv = Ref{ElInt}(0)
-            ElError(ccall(($(string("ElDistMatrixColOwner_", ext)), libEl), Cuint,
-                (Ptr{Cvoid}, ElInt, Ref{ElInt}),
-                A.obj, i - 1, rv))
-            return rv[]
-        end
-
     end
 end
 

--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -100,7 +100,7 @@ for (elty, ext) in ((:ElInt, :i),
             return rv[]
         end
 
-        function processPullQueue(A::DistMatrix{$elty}, buf::Array{$elty,2})
+        function processPullQueue(A::DistMatrix{$elty}, buf::AbstractArray{$elty,2})
             ElError(ccall(($(string("ElDistMatrixProcessPullQueue_", ext)), libEl), Cuint,
                 (Ptr{Cvoid}, Ptr{$elty}),
                 A.obj, buf))
@@ -148,6 +148,23 @@ for (elty, ext) in ((:ElInt, :i),
                 A.obj, i, j))
             return A
         end
+        
+        function isLocalRow(A::DistMatrix{$elty}, i::Integer)
+            rv = Ref{ElInt}(0)
+            ElError(ccall(($(string("ElDistMatrixIsLocalRow_", ext)), libEl), Cuint,
+                (Ptr{Cvoid}, ElInt, Ref{ElInt}),
+                A.obj, i - 1, rv))
+            return Bool(rv[])
+        end
+
+        function isLocalCol(A::DistMatrix{$elty}, i::Integer)
+            rv = Ref{ElInt}(0)
+            ElError(ccall(($(string("ElDistMatrixIsLocalCol_", ext)), libEl), Cuint,
+                (Ptr{Cvoid}, ElInt, Ref{ElInt}),
+                A.obj, i - 1, rv))
+            return Bool(rv[])
+        end
+
     end
 end
 

--- a/src/core/distmatrix.jl
+++ b/src/core/distmatrix.jl
@@ -100,7 +100,7 @@ for (elty, ext) in ((:ElInt, :i),
             return rv[]
         end
 
-        function processPullQueue(A::DistMatrix{$elty}, buf::AbstractArray{$elty,2})
+        function processPullQueue(A::DistMatrix{$elty}, buf::Array{$elty,2})
             ElError(ccall(($(string("ElDistMatrixProcessPullQueue_", ext)), libEl), Cuint,
                 (Ptr{Cvoid}, Ptr{$elty}),
                 A.obj, buf))

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -186,13 +186,13 @@ function Base.setindex!(A::DistMatrix,
                         values,
                         globalis,
                         globaljs)
-  if typeof(values) <: Number
-    @warn "setindex! with scalars won't perform well"
-  end
-  for (cj, globalj) in enumerate(globaljs), (ci, globali) in enumerate(globalis)
-    queueUpdate(A, globali, globalj, values[ci, cj])
-  end
-  processQueues(A)
+    if typeof(values) <: Number
+        @warn "setindex! with scalars won't perform well"
+    end
+    for (cj, globalj) in enumerate(globaljs), (ci, globali) in enumerate(globalis)
+        queueUpdate(A, globali, globalj, values[ci, cj])
+    end
+    processQueues(A)
 end
 
 

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -194,6 +194,11 @@ LinearAlgebra.cholesky!(A::Hermitian{<:Union{Real,Complex},<:ElementalMatrix}) =
 LinearAlgebra.cholesky(A::Hermitian{<:Union{Real,Complex},<:ElementalMatrix}) = cholesky!(copy(A))
 
 LinearAlgebra.lu(A::ElementalMatrix) = _lu!(copy(A))
+LinearAlgebra.lu!(A::ElementalMatrix) = _lu!(A)
+LinearAlgebra.qr(A::ElementalMatrix) = _qr!(copy(A))
+LinearAlgebra.qr!(A::ElementalMatrix) = _qr!(A)
+LinearAlgebra.lq(A::ElementalMatrix) = _lq!(copy(A))
+LinearAlgebra.lq!(A::ElementalMatrix) = _lq!(A)
 
 # Mixed multiplication with Julia Arrays
 (*)(A::DistMatrix{T}, B::StridedVecOrMat{T}) where {T} = A*convert(DistMatrix{T}, B)

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -199,6 +199,7 @@ LinearAlgebra.qr(A::ElementalMatrix) = _qr!(copy(A))
 LinearAlgebra.qr!(A::ElementalMatrix) = _qr!(A)
 LinearAlgebra.lq(A::ElementalMatrix) = _lq!(copy(A))
 LinearAlgebra.lq!(A::ElementalMatrix) = _lq!(A)
+LinearAlgebra.cholesky!(A::ElementalMatrix) = _cholesky!(A)
 
 # Mixed multiplication with Julia Arrays
 (*)(A::DistMatrix{T}, B::StridedVecOrMat{T}) where {T} = A*convert(DistMatrix{T}, B)

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -181,8 +181,6 @@ Base.convert(::Type{Array}, xd::DistMatrix{T}) where {T} =
 
 Base.Array(xd::DistMatrix) = convert(Array, xd)
 
-# super slow, but handy?
-
 function Base.setindex!(A::DistMatrix, values::Number, _, _)
   throw(ArgumentError("setindex! with scalars is disallowed.
     Use a large collection to setindex! in bulk."))

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -182,11 +182,15 @@ Base.convert(::Type{Array}, xd::DistMatrix{T}) where {T} =
 Base.Array(xd::DistMatrix) = convert(Array, xd)
 
 # super slow, but handy?
+
+function Base.setindex!(A::DistMatrix, values::Number, _, _)
+  throw(ArgumentError("setindex! with scalars is disallowed.
+    Use a large collection to setindex! in bulk."))
+end
 function Base.setindex!(A::DistMatrix,
                         values,
                         globalis,
                         globaljs)
-    values isa Number && @warn "setindex! with scalars won't perform well"
     for (cj, globalj) in enumerate(globaljs), (ci, globali) in enumerate(globalis)
         queueUpdate(A, globali, globalj, values[ci, cj])
     end

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -186,9 +186,7 @@ function Base.setindex!(A::DistMatrix,
                         values,
                         globalis,
                         globaljs)
-    if typeof(values) <: Number
-        @warn "setindex! with scalars won't perform well"
-    end
+    values isa Number && @warn "setindex! with scalars won't perform well"
     for (cj, globalj) in enumerate(globaljs), (ci, globali) in enumerate(globalis)
         queueUpdate(A, globali, globalj, values[ci, cj])
     end

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -181,7 +181,7 @@ Base.convert(::Type{Array}, xd::DistMatrix{T}) where {T} =
 
 Base.Array(xd::DistMatrix) = convert(Array, xd)
 
-function Base.setindex!(A::DistMatrix, values::Number, _, _)
+function Base.setindex!(A::DistMatrix, values::Number, i::Integer, j::Integer)
   throw(ArgumentError("setindex! with scalars is disallowed.
     Use a large collection to setindex! in bulk."))
 end

--- a/src/julia/generic.jl
+++ b/src/julia/generic.jl
@@ -181,6 +181,21 @@ Base.convert(::Type{Array}, xd::DistMatrix{T}) where {T} =
 
 Base.Array(xd::DistMatrix) = convert(Array, xd)
 
+# super slow, but handy?
+function Base.setindex!(A::DistMatrix,
+                        values,
+                        globalis,
+                        globaljs)
+  if typeof(values) <: Number
+    @warn "setindex! with scalars won't perform well"
+  end
+  for (cj, globalj) in enumerate(globaljs), (ci, globali) in enumerate(globalis)
+    queueUpdate(A, globali, globalj, values[ci, cj])
+  end
+  processQueues(A)
+end
+
+
 LinearAlgebra.norm(x::ElementalMatrix) = nrm2(x)
 # function LinearAlgebra.norm(x::ElementalMatrix)
 #     if size(x, 2) == 1

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -105,7 +105,7 @@ for mattype in ("", "Dist")
   QRStructName = Symbol("QR$(string(mattype))")
   LQStructName = Symbol("LQ$(string(mattype))")
   LUStructName = Symbol("LU$(string(mattype))")
-  CHStructName = Symbol("CH$(string(mattype))")
+  CHStructName = Symbol("Cholesky$(string(mattype))")
 
   @eval begin
   #struct $QRColPivStructName{T,U<:Real}
@@ -148,13 +148,13 @@ for mattype in ("", "Dist")
     return $LUStructName(A, p, Ref(NORMAL::Orientation))
   end
 
-  struct $CHStructName{T,U<:Real}
+  struct $CHStructName{T}
     uplo::UpperOrLower
     A::$mat{T}
     orientation::Ref{Orientation}
   end
-  function $QRStructName(uplo::UpperOrLower, A)
-    return $QRStructName(uplo, A, Ref(NORMAL::Orientation))
+  function $CHStructName(uplo::UpperOrLower, A)
+    return $CHStructName(uplo, A, Ref(NORMAL::Orientation))
   end
 
   end
@@ -247,9 +247,9 @@ for mattype in ("", "Dist")
 
     function LinearAlgebra.:\(ch::$CHStructName{$elty}, b::$mat{$elty})
       x = deepcopy(b)#$mat($elty)
-      ElError(ccall(($(string("ElSolveAfterCholeksy", mattype, "_", ext)), libEl), Cuint,
+      ElError(ccall(($(string("ElSolveAfterCholesky", mattype, "_", ext)), libEl), Cuint,
         (UpperOrLower, Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
-        lu.uplo, lu.orientation[], lu.A.obj, x.obj))
+        ch.uplo, ch.orientation[], ch.A.obj, x.obj))
       return x
     end
 

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -92,14 +92,140 @@ for mattype in ("", "Dist")
                     uplo, A.obj))
                 return A
             end
-
-            function _lu!(A::$mat{$elty})
-                p = $_p()
-                ElError(ccall(($(string("ElLUPartialPiv", mattype, "_", ext)), libEl), Cuint,
-                    (Ptr{Cvoid}, Ptr{Cvoid}),
-                    A.obj, p.obj))
-                return A, p
-            end
         end
     end
+end
+
+for mattype in ("", "Dist")
+  mat = Symbol(mattype, "Matrix")
+  _p  = Symbol(mattype, "Permutation")
+
+  QRColPivStructName = Symbol("QRColPiv$(string(mattype))")
+  QRStructName = Symbol("QR$(string(mattype))")
+  LQStructName = Symbol("LQ$(string(mattype))")
+  LUStructName = Symbol("LU$(string(mattype))")
+
+  @eval begin
+  struct $QRColPivStructName{T,U<:Real}
+    A::$mat{T}
+    t::$mat{T}
+    d::$mat{U}
+    p::$_p
+    orientation::Ref{Orientation}
+  end
+  function $QRColPivStructName(A, t, d, p)
+    return $QRColPivStructName(A, t, d, p, Ref(NORMAL::Orientation))
+  end
+
+  struct $QRStructName{T,U<:Real}
+    A::$mat{T}
+    t::$mat{T}
+    d::$mat{U}
+    orientation::Ref{Orientation}
+  end
+  function $QRStructName(A, t, d)
+    return $QRStructName(A, t, d, Ref(NORMAL::Orientation))
+  end
+
+  struct $LQStructName{T, U<:Real}
+    A::$mat{T}
+    householderscalars::$mat{T}
+    signature::$mat{U}
+    orientation::Ref{Orientation}
+  end
+  function $LQStructName(A, householderscalars, signature)
+    return $LQStructName(A, householderscalars, signature, Ref(NORMAL::Orientation))
+  end
+
+  struct $LUStructName{T}
+    A::$mat{T}
+    p::$_p
+    orientation::Ref{Orientation}
+  end
+  function $LUStructName(A, p)
+    return $LUStructName(A, p, Ref(NORMAL::Orientation))
+  end
+
+  end
+
+  for (elty, ext) in ((:Float32, :s),
+                      (:Float64, :d),
+                      (:ComplexF32, :c),
+                      (:ComplexF64, :z))
+
+    @eval begin
+
+    function _lu!(A::$mat{$elty})
+      p = $_p()
+      ElError(ccall(($(string("ElLUPartialPiv", mattype, "_", ext)), libEl), Cuint,
+        (Ptr{Cvoid}, Ptr{Cvoid}),
+        A.obj, p.obj))
+      return $LUStructName(A, p)
+    end
+    function LinearAlgebra.:\(lu::$LUStructName{$elty}, b::$mat{$elty})
+      x = deepcopy(b)#$mat($elty)
+      ElError(ccall(($(string("ElSolveAfterLU", mattype, "_", ext)), libEl), Cuint,
+        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
+        lu.orientation[], lu.A.obj, x.obj))
+      return x
+    end
+
+    function _qrcp!(A::$mat{$elty})
+      t = $mat($elty)
+      d = $mat(real($elty))
+      p = $_p()
+      ElError(ccall(($(string("ElQRColPiv", mattype, "_", ext)), libEl), Cuint,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        A.obj, t.obj, d.obj, p.obj))
+      return $QRColPivStructName(A, t, d, p)
+    end
+
+    function LinearAlgebra.:\(qr::$QRColPivStructName{$elty}, b::$mat{$elty})
+      x = $mat($elty)
+      ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
+        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
+      ElError(ccall(($(string("El", mattype, "PermutationPermuteRows", "_", ext)), libEl), Cuint,
+        (Ptr{Cvoid}, Ptr{Cvoid}, ElInt),
+         qr.p.obj, x.obj, 0))
+      return x
+    end
+
+    function _qr!(A::$mat{$elty})
+      t = $mat($elty)
+      d = $mat(real($elty))
+      ElError(ccall(($(string("ElQR", mattype, "_", ext)), libEl), Cuint,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        A.obj, t.obj, d.obj))
+      return $QRStructName(A, t, d)
+    end
+
+    function LinearAlgebra.:\(qr::$QRStructName{$elty}, b::$mat{$elty})
+      x = $mat($elty)
+      ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
+        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
+      return x
+    end
+
+    function _lq!(A::$mat{$elty})
+      householderscalars = $mat($elty)
+      signature = $mat(real($elty))
+      ElError(ccall(($(string("ElLQ", mattype, "_", ext)), libEl), Cuint,
+        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        A.obj, householderscalars.obj, signature.obj))
+      return $LQStructName(A, householderscalars, signature)
+    end
+
+    function LinearAlgebra.:\(lq::$LQStructName{$elty}, b::$mat{$elty})
+      x = $mat($elty)
+      ElError(ccall(($(string("ElSolveAfterLQ", mattype, "_", ext)), libEl), Cuint,
+        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+        lq.orientation[], lq.A.obj, lq.householderscalars.obj,
+        lq.signature.obj, b.obj, x.obj))
+      return x
+    end
+
+    end
+  end
 end

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -100,22 +100,23 @@ for mattype in ("", "Dist")
   mat = Symbol(mattype, "Matrix")
   _p  = Symbol(mattype, "Permutation")
 
-  QRColPivStructName = Symbol("QRColPiv$(string(mattype))")
+  # TODO - fix QRColPiv
+  #QRColPivStructName = Symbol("QRColPiv$(string(mattype))")
   QRStructName = Symbol("QR$(string(mattype))")
   LQStructName = Symbol("LQ$(string(mattype))")
   LUStructName = Symbol("LU$(string(mattype))")
 
   @eval begin
-  struct $QRColPivStructName{T,U<:Real}
-    A::$mat{T}
-    t::$mat{T}
-    d::$mat{U}
-    p::$_p
-    orientation::Ref{Orientation}
-  end
-  function $QRColPivStructName(A, t, d, p)
-    return $QRColPivStructName(A, t, d, p, Ref(NORMAL::Orientation))
-  end
+  #struct $QRColPivStructName{T,U<:Real}
+  #  A::$mat{T}
+  #  t::$mat{T}
+  #  d::$mat{U}
+  #  p::$_p
+  #  orientation::Ref{Orientation}
+  #end
+  #function $QRColPivStructName(A, t, d, p)
+  #  return $QRColPivStructName(A, t, d, p, Ref(NORMAL::Orientation))
+  #end
 
   struct $QRStructName{T,U<:Real}
     A::$mat{T}
@@ -170,26 +171,25 @@ for mattype in ("", "Dist")
       return x
     end
 
-    function _qrcp!(A::$mat{$elty})
-      t = $mat($elty)
-      d = $mat(real($elty))
-      p = $_p()
-      ElError(ccall(($(string("ElQRColPiv", mattype, "_", ext)), libEl), Cuint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        A.obj, t.obj, d.obj, p.obj))
-      return $QRColPivStructName(A, t, d, p)
-    end
-
-    function LinearAlgebra.:\(qr::$QRColPivStructName{$elty}, b::$mat{$elty})
-      x = $mat($elty)
-      ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
-        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
-      ElError(ccall(($(string("El", mattype, "PermutationPermuteRows", "_", ext)), libEl), Cuint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, ElInt),
-         qr.p.obj, x.obj, 0))
-      return x
-    end
+    #function _qrcp!(A::$mat{$elty})
+    #  t = $mat($elty)
+    #  d = $mat(real($elty))
+    #  p = $_p()
+    #  ElError(ccall(($(string("ElQRColPiv", mattype, "_", ext)), libEl), Cuint,
+    #    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+    #    A.obj, t.obj, d.obj, p.obj))
+    #  return $QRColPivStructName(A, t, d, p)
+    #end
+    #function LinearAlgebra.:\(qr::$QRColPivStructName{$elty}, b::$mat{$elty})
+    #  x = $mat($elty)
+    #  ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
+    #    (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+    #    qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
+    #  ElError(ccall(($(string("El", mattype, "PermutationPermuteRows", "_", ext)), libEl), Cuint,
+    #    (Ptr{Cvoid}, Ptr{Cvoid}, ElInt),
+    #     qr.p.obj, x.obj, 0))
+    #  return x
+    #end
 
     function _qr!(A::$mat{$elty})
       t = $mat($elty)

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -97,131 +97,131 @@ for mattype in ("", "Dist")
 end
 
 for mattype in ("", "Dist")
-  mat = Symbol(mattype, "Matrix")
-  _p  = Symbol(mattype, "Permutation")
+    mat = Symbol(mattype, "Matrix")
+    _p  = Symbol(mattype, "Permutation")
 
-  # TODO - fix QRColPiv
-  #QRColPivStructName = Symbol("QRColPiv$(string(mattype))")
-  QRStructName = Symbol("QR$(string(mattype))")
-  LQStructName = Symbol("LQ$(string(mattype))")
-  LUStructName = Symbol("LU$(string(mattype))")
-  CHStructName = Symbol("Cholesky$(string(mattype))")
-
-  @eval begin
-
-  struct $QRStructName{T,U<:Real}
-    A::$mat{T}
-    t::$mat{T}
-    d::$mat{U}
-    orientation::Ref{Orientation}
-  end
-  function $QRStructName(A, t, d)
-    return $QRStructName(A, t, d, Ref(NORMAL::Orientation))
-  end
-
-  struct $LQStructName{T, U<:Real}
-    A::$mat{T}
-    householderscalars::$mat{T}
-    signature::$mat{U}
-    orientation::Ref{Orientation}
-  end
-  function $LQStructName(A, householderscalars, signature)
-    return $LQStructName(A, householderscalars, signature, Ref(NORMAL::Orientation))
-  end
-
-  struct $LUStructName{T}
-    A::$mat{T}
-    p::$_p
-    orientation::Ref{Orientation}
-  end
-  function $LUStructName(A, p)
-    return $LUStructName(A, p, Ref(NORMAL::Orientation))
-  end
-
-  struct $CHStructName{T}
-    uplo::UpperOrLower
-    A::$mat{T}
-    orientation::Ref{Orientation}
-  end
-  function $CHStructName(uplo::UpperOrLower, A)
-    return $CHStructName(uplo, A, Ref(NORMAL::Orientation))
-  end
-
-  end
-
-  for (elty, ext) in ((:Float32, :s),
-                      (:Float64, :d),
-                      (:ComplexF32, :c),
-                      (:ComplexF64, :z))
+    # TODO - fix QRColPiv
+    #QRColPivStructName = Symbol("QRColPiv$(string(mattype))")
+    QRStructName = Symbol("QR$(string(mattype))")
+    LQStructName = Symbol("LQ$(string(mattype))")
+    LUStructName = Symbol("LU$(string(mattype))")
+    CHStructName = Symbol("Cholesky$(string(mattype))")
 
     @eval begin
 
-    function _lu!(A::$mat{$elty})
-      p = $_p()
-      ElError(ccall(($(string("ElLU", mattype, "_", ext)), libEl), Cuint,
-        (Ptr{Cvoid}, Ptr{Cvoid}),
-        A.obj, p.obj))
-      return $LUStructName(A, p)
-    end
+        struct $QRStructName{T,U<:Real}
+            A::$mat{T}
+            t::$mat{T}
+            d::$mat{U}
+            orientation::Ref{Orientation}
+        end
+        function $QRStructName(A, t, d)
+            return $QRStructName(A, t, d, Ref(NORMAL::Orientation))
+        end
 
-    function LinearAlgebra.:\(lu::$LUStructName{$elty}, b::$mat{$elty})
-      x = deepcopy(b)#$mat($elty)
-      ElError(ccall(($(string("ElSolveAfterLU", mattype, "_", ext)), libEl), Cuint,
-        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
-        lu.orientation[], lu.A.obj, x.obj))
-      return x
-    end
+        struct $LQStructName{T, U<:Real}
+            A::$mat{T}
+            householderscalars::$mat{T}
+            signature::$mat{U}
+            orientation::Ref{Orientation}
+        end
+        function $LQStructName(A, householderscalars, signature)
+            return $LQStructName(A, householderscalars, signature, Ref(NORMAL::Orientation))
+        end
 
-    function _qr!(A::$mat{$elty})
-      t = $mat($elty)
-      d = $mat(real($elty))
-      ElError(ccall(($(string("ElQR", mattype, "_", ext)), libEl), Cuint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        A.obj, t.obj, d.obj))
-      return $QRStructName(A, t, d)
-    end
+        struct $LUStructName{T}
+            A::$mat{T}
+            p::$_p
+            orientation::Ref{Orientation}
+        end
+        function $LUStructName(A, p)
+            return $LUStructName(A, p, Ref(NORMAL::Orientation))
+        end
 
-    function LinearAlgebra.:\(qr::$QRStructName{$elty}, b::$mat{$elty})
-      x = $mat($elty)
-      ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
-        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
-      return x
-    end
-
-    function _lq!(A::$mat{$elty})
-      householderscalars = $mat($elty)
-      signature = $mat(real($elty))
-      ElError(ccall(($(string("ElLQ", mattype, "_", ext)), libEl), Cuint,
-        (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        A.obj, householderscalars.obj, signature.obj))
-      return $LQStructName(A, householderscalars, signature)
-    end
-
-    function LinearAlgebra.:\(lq::$LQStructName{$elty}, b::$mat{$elty})
-      x = $mat($elty)
-      ElError(ccall(($(string("ElSolveAfterLQ", mattype, "_", ext)), libEl), Cuint,
-        (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-        lq.orientation[], lq.A.obj, lq.householderscalars.obj,
-        lq.signature.obj, b.obj, x.obj))
-      return x
-    end
-
-    function _cholesky!(A::$mat{$elty}, uplo::UpperOrLower=UPPER::UpperOrLower)
-      ElError(ccall(($(string("ElCholesky", mattype, "_", ext)), libEl), Cuint,
-        (UpperOrLower, Ptr{Cvoid}),
-        uplo, A.obj))
-      return $CHStructName(uplo, A)
-    end
-
-    function LinearAlgebra.:\(ch::$CHStructName{$elty}, b::$mat{$elty})
-      x = deepcopy(b)#$mat($elty)
-      ElError(ccall(($(string("ElSolveAfterCholesky", mattype, "_", ext)), libEl), Cuint,
-        (UpperOrLower, Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
-        ch.uplo, ch.orientation[], ch.A.obj, x.obj))
-      return x
-    end
+        struct $CHStructName{T}
+            uplo::UpperOrLower
+            A::$mat{T}
+            orientation::Ref{Orientation}
+        end
+        function $CHStructName(uplo::UpperOrLower, A)
+            return $CHStructName(uplo, A, Ref(NORMAL::Orientation))
+        end
 
     end
-  end
+
+    for (elty, ext) in ((:Float32, :s),
+                        (:Float64, :d),
+                        (:ComplexF32, :c),
+                        (:ComplexF64, :z))
+
+        @eval begin
+
+            function _lu!(A::$mat{$elty})
+                p = $_p()
+                ElError(ccall(($(string("ElLU", mattype, "_", ext)), libEl), Cuint,
+                              (Ptr{Cvoid}, Ptr{Cvoid}),
+                              A.obj, p.obj))
+                return $LUStructName(A, p)
+            end
+
+            function LinearAlgebra.:\(lu::$LUStructName{$elty}, b::$mat{$elty})
+                x = deepcopy(b)#$mat($elty)
+                ElError(ccall(($(string("ElSolveAfterLU", mattype, "_", ext)), libEl), Cuint,
+                              (Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
+                              lu.orientation[], lu.A.obj, x.obj))
+                return x
+            end
+
+            function _qr!(A::$mat{$elty})
+                t = $mat($elty)
+                d = $mat(real($elty))
+                ElError(ccall(($(string("ElQR", mattype, "_", ext)), libEl), Cuint,
+                              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+                              A.obj, t.obj, d.obj))
+                return $QRStructName(A, t, d)
+            end
+
+            function LinearAlgebra.:\(qr::$QRStructName{$elty}, b::$mat{$elty})
+                x = $mat($elty)
+                ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
+                              (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+                              qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
+                return x
+            end
+
+            function _lq!(A::$mat{$elty})
+                householderscalars = $mat($elty)
+                signature = $mat(real($elty))
+                ElError(ccall(($(string("ElLQ", mattype, "_", ext)), libEl), Cuint,
+                              (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+                              A.obj, householderscalars.obj, signature.obj))
+                return $LQStructName(A, householderscalars, signature)
+            end
+
+            function LinearAlgebra.:\(lq::$LQStructName{$elty}, b::$mat{$elty})
+                x = $mat($elty)
+                ElError(ccall(($(string("ElSolveAfterLQ", mattype, "_", ext)), libEl), Cuint,
+                              (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
+                              lq.orientation[], lq.A.obj, lq.householderscalars.obj,
+                              lq.signature.obj, b.obj, x.obj))
+                return x
+            end
+
+            function _cholesky!(A::$mat{$elty}, uplo::UpperOrLower=UPPER::UpperOrLower)
+                ElError(ccall(($(string("ElCholesky", mattype, "_", ext)), libEl), Cuint,
+                              (UpperOrLower, Ptr{Cvoid}),
+                              uplo, A.obj))
+                return $CHStructName(uplo, A)
+            end
+
+            function LinearAlgebra.:\(ch::$CHStructName{$elty}, b::$mat{$elty})
+                x = deepcopy(b)#$mat($elty)
+                ElError(ccall(($(string("ElSolveAfterCholesky", mattype, "_", ext)), libEl), Cuint,
+                              (UpperOrLower, Orientation, Ptr{Cvoid}, Ptr{Cvoid}),
+                              ch.uplo, ch.orientation[], ch.A.obj, x.obj))
+                return x
+            end
+
+        end
+    end
 end

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -108,16 +108,6 @@ for mattype in ("", "Dist")
   CHStructName = Symbol("Cholesky$(string(mattype))")
 
   @eval begin
-  #struct $QRColPivStructName{T,U<:Real}
-  #  A::$mat{T}
-  #  t::$mat{T}
-  #  d::$mat{U}
-  #  p::$_p
-  #  orientation::Ref{Orientation}
-  #end
-  #function $QRColPivStructName(A, t, d, p)
-  #  return $QRColPivStructName(A, t, d, p, Ref(NORMAL::Orientation))
-  #end
 
   struct $QRStructName{T,U<:Real}
     A::$mat{T}
@@ -181,27 +171,6 @@ for mattype in ("", "Dist")
         lu.orientation[], lu.A.obj, x.obj))
       return x
     end
-
-    #function _qrcp!(A::$mat{$elty})
-    #  t = $mat($elty)
-    #  d = $mat(real($elty))
-    #  p = $_p()
-    #  ElError(ccall(($(string("ElQRColPiv", mattype, "_", ext)), libEl), Cuint,
-    #    (Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-    #    A.obj, t.obj, d.obj, p.obj))
-    #  return $QRColPivStructName(A, t, d, p)
-    #end
-    #
-    #function LinearAlgebra.:\(qr::$QRColPivStructName{$elty}, b::$mat{$elty})
-    #  x = $mat($elty)
-    #  ElError(ccall(($(string("ElSolveAfterQR", mattype, "_", ext)), libEl), Cuint,
-    #    (Orientation, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}, Ptr{Cvoid}),
-    #    qr.orientation[], qr.A.obj, qr.t.obj, qr.d.obj, b.obj, x.obj))
-    #  ElError(ccall(($(string("El", mattype, "PermutationPermuteRows", "_", ext)), libEl), Cuint,
-    #    (Ptr{Cvoid}, Ptr{Cvoid}, ElInt),
-    #     qr.p.obj, x.obj, 0))
-    #  return x
-    #end
 
     function _qr!(A::$mat{$elty})
       t = $mat($elty)

--- a/src/lapack_like/factor.jl
+++ b/src/lapack_like/factor.jl
@@ -96,6 +96,8 @@ for mattype in ("", "Dist")
     end
 end
 
+# These are the number types that Elemental supports
+
 for mattype in ("", "Dist")
     mat = Symbol(mattype, "Matrix")
     _p  = Symbol(mattype, "Permutation")
@@ -115,7 +117,8 @@ for mattype in ("", "Dist")
             d::$mat{U}
             orientation::Ref{Orientation}
         end
-        function $QRStructName(A, t, d)
+        function $QRStructName(A::$mat{T}, t::$mat{T}, d::$mat{U}
+                ) where {U<:Union{Float32, Float64}, T<:Union{Complex{U}, U}}
             return $QRStructName(A, t, d, Ref(NORMAL::Orientation))
         end
 
@@ -125,7 +128,8 @@ for mattype in ("", "Dist")
             signature::$mat{U}
             orientation::Ref{Orientation}
         end
-        function $LQStructName(A, householderscalars, signature)
+        function $LQStructName(A::$mat{T}, householderscalars::$mat{T}, signature::$mat{U}
+                ) where {U<:Union{Float32, Float64}, T<:Union{Complex{U}, U}}
             return $LQStructName(A, householderscalars, signature, Ref(NORMAL::Orientation))
         end
 
@@ -134,7 +138,8 @@ for mattype in ("", "Dist")
             p::$_p
             orientation::Ref{Orientation}
         end
-        function $LUStructName(A, p)
+        function $LUStructName(A::$mat{T}, p::$_p
+                ) where {T<:Union{Float32, Float64, ComplexF32, ComplexF64}}
             return $LUStructName(A, p, Ref(NORMAL::Orientation))
         end
 
@@ -143,7 +148,8 @@ for mattype in ("", "Dist")
             A::$mat{T}
             orientation::Ref{Orientation}
         end
-        function $CHStructName(uplo::UpperOrLower, A)
+        function $CHStructName(uplo::UpperOrLower, A::$mat{T}
+                ) where {T<:Union{Float32, Float64, ComplexF32, ComplexF64}}
             return $CHStructName(uplo, A, Ref(NORMAL::Orientation))
         end
 

--- a/test/distcholesky.jl
+++ b/test/distcholesky.jl
@@ -39,5 +39,5 @@ const bhost = rand(Float64, M)
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
 @testset "Cholesky" begin
-  @test x ≈ Ahost \ bhost
+    @test x ≈ Ahost \ bhost
 end

--- a/test/distcholesky.jl
+++ b/test/distcholesky.jl
@@ -33,21 +33,8 @@ const bhost = rand(Float64, M)
 
 @mpi_do man x = chA \ b;
 
-@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
-  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
-  return localpart!(buffer, A)
-end
-
-@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
-  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
-  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
-    buffer[i, j] = Elemental.getLocal(A, i, j)
-  end
-  return buffer
-end
-
 @mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
-@mpi_do man copyto!(localx, localpart(x))
+@mpi_do man copyto!(localx, Elemental.localpart(x))
 
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)

--- a/test/distcholesky.jl
+++ b/test/distcholesky.jl
@@ -1,0 +1,56 @@
+using MPI, MPIClusterManagers, Distributed
+
+man = MPIManager(np = 2);
+
+addprocs(man);
+
+@everywhere using LinearAlgebra, Elemental
+
+const M = 400
+const N = M
+
+@mpi_do man M = @fetchfrom 1 M
+@mpi_do man N = @fetchfrom 1 N
+
+const Ahost = rand(Float64, M, N)
+Ahost .+= Ahost'
+Ahost .+= M * I(M)
+const bhost = rand(Float64, M)
+
+@mpi_do man Aall = @fetchfrom 1 Ahost
+@mpi_do man ball = @fetchfrom 1 bhost
+
+@mpi_do man A = Elemental.DistMatrix(Float64);
+@mpi_do man b = Elemental.DistMatrix(Float64);
+
+@mpi_do man A = Elemental.resize!(A, M, N);
+@mpi_do man b = Elemental.resize!(b, M);
+
+@mpi_do man copyto!(A, Aall)
+@mpi_do man copyto!(b, ball)
+
+@mpi_do man chA = Elemental.cholesky!(A);
+
+@mpi_do man x = chA \ b;
+
+@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
+  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
+  return localpart!(buffer, A)
+end
+
+@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
+  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
+  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
+    buffer[i, j] = Elemental.getLocal(A, i, j)
+  end
+  return buffer
+end
+
+@mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
+@mpi_do man copyto!(localx, localpart(x))
+
+using Test
+x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
+@testset "Cholesky" begin
+  @test x ≈ Ahost \ bhost
+end

--- a/test/distlq.jl
+++ b/test/distlq.jl
@@ -1,0 +1,54 @@
+using MPI, MPIClusterManagers, Distributed
+
+man = MPIManager(np = 2);
+
+addprocs(man);
+
+@everywhere using LinearAlgebra, Elemental
+
+const M = 300
+const N = 400
+
+@mpi_do man M = @fetchfrom 1 M
+@mpi_do man N = @fetchfrom 1 N
+
+const Ahost = rand(Float64, M, N)
+const bhost = rand(Float64, M)
+
+@mpi_do man Aall = @fetchfrom 1 Ahost
+@mpi_do man ball = @fetchfrom 1 bhost
+
+@mpi_do man A = Elemental.DistMatrix(Float64);
+@mpi_do man b = Elemental.DistMatrix(Float64);
+
+@mpi_do man A = Elemental.resize!(A, M, N);
+@mpi_do man b = Elemental.resize!(b, M);
+
+@mpi_do man copyto!(A, Aall)
+@mpi_do man copyto!(b, ball)
+
+@mpi_do man lqA = Elemental.lq!(A);
+
+@mpi_do man x = lqA \ b;
+
+@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
+  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
+  return localpart!(buffer, A)
+end
+
+@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
+  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
+  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
+    buffer[i, j] = Elemental.getLocal(A, i, j)
+  end
+  return buffer
+end
+
+@mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
+@mpi_do man copyto!(localx, localpart(x))
+
+using Test
+x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
+@testset "lq" begin
+  @test x ≈ Ahost \ bhost
+end

--- a/test/distlq.jl
+++ b/test/distlq.jl
@@ -37,5 +37,5 @@ const bhost = rand(Float64, M)
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
 @testset "lq" begin
-  @test x ≈ Ahost \ bhost
+    @test x ≈ Ahost \ bhost
 end

--- a/test/distlq.jl
+++ b/test/distlq.jl
@@ -31,21 +31,8 @@ const bhost = rand(Float64, M)
 
 @mpi_do man x = lqA \ b;
 
-@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
-  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
-  return localpart!(buffer, A)
-end
-
-@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
-  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
-  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
-    buffer[i, j] = Elemental.getLocal(A, i, j)
-  end
-  return buffer
-end
-
 @mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
-@mpi_do man copyto!(localx, localpart(x))
+@mpi_do man copyto!(localx, Elemental.localpart(x))
 
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)

--- a/test/distlu.jl
+++ b/test/distlu.jl
@@ -37,5 +37,5 @@ const bhost = rand(Float64, M)
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
 @testset "lu" begin
-  @test x ≈ Ahost \ bhost
+    @test x ≈ Ahost \ bhost
 end

--- a/test/distlu.jl
+++ b/test/distlu.jl
@@ -1,0 +1,54 @@
+using MPI, MPIClusterManagers, Distributed
+
+man = MPIManager(np = 2);
+
+addprocs(man);
+
+@everywhere using LinearAlgebra, Elemental
+
+const M = 400
+const N = M
+
+@mpi_do man M = @fetchfrom 1 M
+@mpi_do man N = @fetchfrom 1 N
+
+const Ahost = rand(Float64, M, N)
+const bhost = rand(Float64, M)
+
+@mpi_do man Aall = @fetchfrom 1 Ahost
+@mpi_do man ball = @fetchfrom 1 bhost
+
+@mpi_do man A = Elemental.DistMatrix(Float64);
+@mpi_do man b = Elemental.DistMatrix(Float64);
+
+@mpi_do man A = Elemental.resize!(A, M, N);
+@mpi_do man b = Elemental.resize!(b, M);
+
+@mpi_do man copyto!(A, Aall)
+@mpi_do man copyto!(b, ball)
+
+@mpi_do man luA = Elemental.lu!(A);
+
+@mpi_do man x = luA \ b;
+
+@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
+  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
+  return localpart!(buffer, A)
+end
+
+@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
+  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
+  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
+    buffer[i, j] = Elemental.getLocal(A, i, j)
+  end
+  return buffer
+end
+
+@mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
+@mpi_do man copyto!(localx, localpart(x))
+
+using Test
+x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
+@testset "lu" begin
+  @test x ≈ Ahost \ bhost
+end

--- a/test/distlu.jl
+++ b/test/distlu.jl
@@ -31,21 +31,8 @@ const bhost = rand(Float64, M)
 
 @mpi_do man x = luA \ b;
 
-@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
-  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
-  return localpart!(buffer, A)
-end
-
-@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
-  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
-  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
-    buffer[i, j] = Elemental.getLocal(A, i, j)
-  end
-  return buffer
-end
-
 @mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
-@mpi_do man copyto!(localx, localpart(x))
+@mpi_do man copyto!(localx, Elemental.localpart(x))
 
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)

--- a/test/distqr.jl
+++ b/test/distqr.jl
@@ -1,0 +1,54 @@
+using MPI, MPIClusterManagers, Distributed
+
+man = MPIManager(np = 2);
+
+addprocs(man);
+
+@everywhere using LinearAlgebra, Elemental
+
+const M = 400
+const N = 300
+
+@mpi_do man M = @fetchfrom 1 M
+@mpi_do man N = @fetchfrom 1 N
+
+const Ahost = rand(Float64, M, N)
+const bhost = rand(Float64, M)
+
+@mpi_do man Aall = @fetchfrom 1 Ahost
+@mpi_do man ball = @fetchfrom 1 bhost
+
+@mpi_do man A = Elemental.DistMatrix(Float64);
+@mpi_do man b = Elemental.DistMatrix(Float64);
+
+@mpi_do man A = Elemental.resize!(A, M, N);
+@mpi_do man b = Elemental.resize!(b, M);
+
+@mpi_do man copyto!(A, Aall)
+@mpi_do man copyto!(b, ball)
+
+@mpi_do man qrA = Elemental.qr!(A);
+
+@mpi_do man x = qrA \ b;
+
+@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
+  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
+  return localpart!(buffer, A)
+end
+
+@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
+  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
+  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
+    buffer[i, j] = Elemental.getLocal(A, i, j)
+  end
+  return buffer
+end
+
+@mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
+@mpi_do man copyto!(localx, localpart(x))
+
+using Test
+x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
+@testset "qr" begin
+  @test x ≈ Ahost \ bhost
+end

--- a/test/distqr.jl
+++ b/test/distqr.jl
@@ -31,21 +31,8 @@ const bhost = rand(Float64, M)
 
 @mpi_do man x = qrA \ b;
 
-@everywhere function localpart(A::Elemental.DistMatrix{T}) where T
-  buffer = zeros(T, Elemental.localHeight(A), Elemental.localWidth(A))
-  return localpart!(buffer, A)
-end
-
-@everywhere function localpart!(buffer, A::Elemental.DistMatrix)
-  @assert size(buffer) == (Elemental.localHeight(A), Elemental.localWidth(A))
-  for j in 1:Elemental.localWidth(A), i in 1:Elemental.localHeight(A)
-    buffer[i, j] = Elemental.getLocal(A, i, j)
-  end
-  return buffer
-end
-
 @mpi_do man localx = zeros(Float64, Elemental.localHeight(x), Elemental.localWidth(x))
-@mpi_do man copyto!(localx, localpart(x))
+@mpi_do man copyto!(localx, Elemental.localpart(x))
 
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)

--- a/test/distqr.jl
+++ b/test/distqr.jl
@@ -37,5 +37,5 @@ const bhost = rand(Float64, M)
 using Test
 x = vcat((fetch(@spawnat p localx)[:] for p in workers())...)
 @testset "qr" begin
-  @test x ≈ Ahost \ bhost
+    @test x ≈ Ahost \ bhost
 end

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -101,19 +101,3 @@ Random.seed!(1)
 
 end
 
-#A2 = Elemental.Matrix(ComplexF64)
-#Elemental.resize!(A2, size(A)...);
-#A2 .= A
-#b1 = Elemental.Matrix(ComplexF64)
-#Elemental.resize!(b1, length(b), 1);
-#b1 .= b
-#qrcp = Elemental._qrcp!(A2)
-#
-#x2 = Vector(Matrix(qrcp \ b1)[:])
-#@show x
-#y = real.(x2)
-#@show y
-#@test isapprox(x2, x)
-
-
-

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -3,100 +3,100 @@ using Elemental, Test, Random, LinearAlgebra
 Random.seed!(1)
 
 @testset "factor" begin
-  @testset "qr!" begin
-    N = 10
-    M = 9
+    @testset "qr!" begin
+        N = 10
+        M = 9
 
-    A = rand(ComplexF64, N, M)
-    b = rand(ComplexF64, N)
+        A = rand(ComplexF64, N, M)
+        b = rand(ComplexF64, N)
 
-    A1 = Elemental.Matrix(ComplexF64)
-    Elemental.resize!(A1, size(A)...);
-    A1 .= A
+        A1 = Elemental.Matrix(ComplexF64)
+        Elemental.resize!(A1, size(A)...);
+        A1 .= A
 
-    qrA = Elemental._qr!(A1)
+        qrA = Elemental._qr!(A1)
 
-    b0 = Elemental.Matrix(ComplexF64)
+        b0 = Elemental.Matrix(ComplexF64)
 
-    Elemental.resize!(b0, length(b), 1);
-    b0 .= b
+        Elemental.resize!(b0, length(b), 1);
+        b0 .= b
 
-    x = A \ b
-    #@show A'*A * x .- A' *b
-    x1 = Vector(Matrix(qrA \ b0)[:])
-    @test isapprox(x1, x)
-  end
-  @testset "lq!" begin
-    N = 9
-    M = 10
+        x = A \ b
+        #@show A'*A * x .- A' *b
+        x1 = Vector(Matrix(qrA \ b0)[:])
+        @test isapprox(x1, x)
+    end
+    @testset "lq!" begin
+        N = 9
+        M = 10
 
-    A = rand(ComplexF64, N, M)
-    b = rand(ComplexF64, N)
+        A = rand(ComplexF64, N, M)
+        b = rand(ComplexF64, N)
 
-    A1 = Elemental.Matrix(ComplexF64)
-    Elemental.resize!(A1, size(A)...);
-    A1 .= A
+        A1 = Elemental.Matrix(ComplexF64)
+        Elemental.resize!(A1, size(A)...);
+        A1 .= A
 
-    lqA = Elemental._lq!(A1)
+        lqA = Elemental._lq!(A1)
 
-    b0 = Elemental.Matrix(ComplexF64)
+        b0 = Elemental.Matrix(ComplexF64)
 
-    Elemental.resize!(b0, length(b), 1);
-    b0 .= b
+        Elemental.resize!(b0, length(b), 1);
+        b0 .= b
 
-    x = A \ b
-    #@show A'*A * x .- A' *b
-    x1 = Vector(Matrix(lqA \ b0)[:])
-    @test isapprox(x1, x)
-  end
-  @testset "lu!" begin
-    N = 10
-    M = 10
+        x = A \ b
+        #@show A'*A * x .- A' *b
+        x1 = Vector(Matrix(lqA \ b0)[:])
+        @test isapprox(x1, x)
+    end
+    @testset "lu!" begin
+        N = 10
+        M = 10
 
-    A = rand(ComplexF64, N, M)
-    b = rand(ComplexF64, N)
+        A = rand(ComplexF64, N, M)
+        b = rand(ComplexF64, N)
 
-    A1 = Elemental.Matrix(ComplexF64)
-    Elemental.resize!(A1, size(A)...);
-    A1 .= A
+        A1 = Elemental.Matrix(ComplexF64)
+        Elemental.resize!(A1, size(A)...);
+        A1 .= A
 
-    luA = Elemental._lu!(A1)
+        luA = Elemental._lu!(A1)
 
-    b0 = Elemental.Matrix(ComplexF64)
+        b0 = Elemental.Matrix(ComplexF64)
 
-    Elemental.resize!(b0, length(b), 1);
-    b0 .= b
+        Elemental.resize!(b0, length(b), 1);
+        b0 .= b
 
-    x = A \ b
-    #@show A'*A * x .- A' *b
-    x1 = Vector(Matrix(luA \ b0)[:])
-    @test isapprox(x1, x)
-  end
-  @testset "cholesky!" begin
-    N = 10
-    M = 10
+        x = A \ b
+        #@show A'*A * x .- A' *b
+        x1 = Vector(Matrix(luA \ b0)[:])
+        @test isapprox(x1, x)
+    end
+    @testset "cholesky!" begin
+        N = 10
+        M = 10
 
-    A = rand(ComplexF64, N, M)
-    A .+= A'
-    A .+= 10 .* I(N)
-    b = rand(ComplexF64, N)
+        A = rand(ComplexF64, N, M)
+        A .+= A'
+        A .+= 10 .* I(N)
+        b = rand(ComplexF64, N)
 
-    A1 = Elemental.Matrix(ComplexF64)
-    Elemental.resize!(A1, size(A)...);
-    A1 .= A
+        A1 = Elemental.Matrix(ComplexF64)
+        Elemental.resize!(A1, size(A)...);
+        A1 .= A
 
-    chA = Elemental._cholesky!(A1)
+        chA = Elemental._cholesky!(A1)
 
-    b0 = Elemental.Matrix(ComplexF64)
+        b0 = Elemental.Matrix(ComplexF64)
 
-    Elemental.resize!(b0, length(b), 1);
-    b0 .= b
+        Elemental.resize!(b0, length(b), 1);
+        b0 .= b
 
-    x = A \ b
-    #@show A'*A * x .- A' *b
-    x1 = Vector(Matrix(chA \ b0)[:])
-    @test isapprox(x1, x)
-  end
+        x = A \ b
+        #@show A'*A * x .- A' *b
+        x1 = Vector(Matrix(chA \ b0)[:])
+        @test isapprox(x1, x)
+    end
 
 
 end

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -4,23 +4,23 @@ Random.seed!(1)
 
 @testset "factor" begin
   @testset "qr!" begin
-    N = 10 
+    N = 10
     M = 9
-    
+
     A = rand(ComplexF64, N, M)
     b = rand(ComplexF64, N)
-    
+
     A1 = Elemental.Matrix(ComplexF64)
     Elemental.resize!(A1, size(A)...);
     A1 .= A
-    
+
     qrA = Elemental._qr!(A1)
-    
+
     b0 = Elemental.Matrix(ComplexF64)
-    
+
     Elemental.resize!(b0, length(b), 1);
     b0 .= b
-    
+
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(qrA \ b0)[:])
@@ -29,69 +29,69 @@ Random.seed!(1)
   @testset "lq!" begin
     N = 9
     M = 10
-    
+
     A = rand(ComplexF64, N, M)
     b = rand(ComplexF64, N)
-    
+
     A1 = Elemental.Matrix(ComplexF64)
     Elemental.resize!(A1, size(A)...);
     A1 .= A
-    
+
     lqA = Elemental._lq!(A1)
-    
+
     b0 = Elemental.Matrix(ComplexF64)
-    
+
     Elemental.resize!(b0, length(b), 1);
     b0 .= b
-    
+
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(lqA \ b0)[:])
     @test isapprox(x1, x)
   end
   @testset "lu!" begin
-    N = 10 
+    N = 10
     M = 10
-    
+
     A = rand(ComplexF64, N, M)
     b = rand(ComplexF64, N)
-    
+
     A1 = Elemental.Matrix(ComplexF64)
     Elemental.resize!(A1, size(A)...);
     A1 .= A
-    
+
     luA = Elemental._lu!(A1)
-    
+
     b0 = Elemental.Matrix(ComplexF64)
-    
+
     Elemental.resize!(b0, length(b), 1);
     b0 .= b
-    
+
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(luA \ b0)[:])
     @test isapprox(x1, x)
   end
   @testset "cholesky!" begin
-    N = 10 
+    N = 10
     M = 10
-    
+
     A = rand(ComplexF64, N, M)
     A .+= A'
     A .+= 10 .* I(N)
     b = rand(ComplexF64, N)
-    
+
     A1 = Elemental.Matrix(ComplexF64)
     Elemental.resize!(A1, size(A)...);
     A1 .= A
-    
+
     chA = Elemental._cholesky!(A1)
-    
+
     b0 = Elemental.Matrix(ComplexF64)
-    
+
     Elemental.resize!(b0, length(b), 1);
     b0 .= b
-    
+
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(chA \ b0)[:])

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -14,7 +14,7 @@ Random.seed!(1)
         Elemental.resize!(A1, size(A)...);
         A1 .= A
 
-        qrA = Elemental._qr!(A1)
+        qrA = Elemental.qr!(A1)
 
         b0 = Elemental.Matrix(ComplexF64)
 
@@ -37,7 +37,7 @@ Random.seed!(1)
         Elemental.resize!(A1, size(A)...);
         A1 .= A
 
-        lqA = Elemental._lq!(A1)
+        lqA = Elemental.lq!(A1)
 
         b0 = Elemental.Matrix(ComplexF64)
 
@@ -60,7 +60,7 @@ Random.seed!(1)
         Elemental.resize!(A1, size(A)...);
         A1 .= A
 
-        luA = Elemental._lu!(A1)
+        luA = Elemental.lu!(A1)
 
         b0 = Elemental.Matrix(ComplexF64)
 
@@ -85,7 +85,7 @@ Random.seed!(1)
         Elemental.resize!(A1, size(A)...);
         A1 .= A
 
-        chA = Elemental._cholesky!(A1)
+        chA = Elemental.cholesky!(A1)
 
         b0 = Elemental.Matrix(ComplexF64)
 

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -1,5 +1,5 @@
 
-using Elemental, Test, Random
+using Elemental, Test, Random, LinearAlgebra
 Random.seed!(1)
 
 @testset "factor" begin
@@ -70,7 +70,6 @@ Random.seed!(1)
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(luA \ b0)[:])
-    @show size(x1)
     @test isapprox(x1, x)
   end
   @testset "cholesky!" begin
@@ -96,7 +95,6 @@ Random.seed!(1)
     x = A \ b
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(chA \ b0)[:])
-    @show size(x1)
     @test isapprox(x1, x)
   end
 

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -68,12 +68,39 @@ Random.seed!(1)
     b0 .= b
     
     x = A \ b
-    @show size(x)
     #@show A'*A * x .- A' *b
     x1 = Vector(Matrix(luA \ b0)[:])
     @show size(x1)
     @test isapprox(x1, x)
   end
+  @testset "cholesky!" begin
+    N = 10 
+    M = 10
+    
+    A = rand(ComplexF64, N, M)
+    A .+= A'
+    A .+= 10 .* I(N)
+    b = rand(ComplexF64, N)
+    
+    A1 = Elemental.Matrix(ComplexF64)
+    Elemental.resize!(A1, size(A)...);
+    A1 .= A
+    
+    chA = Elemental._cholesky!(A1)
+    
+    b0 = Elemental.Matrix(ComplexF64)
+    
+    Elemental.resize!(b0, length(b), 1);
+    b0 .= b
+    
+    x = A \ b
+    #@show A'*A * x .- A' *b
+    x1 = Vector(Matrix(chA \ b0)[:])
+    @show size(x1)
+    @test isapprox(x1, x)
+  end
+
+
 end
 
 #A2 = Elemental.Matrix(ComplexF64)

--- a/test/factor.jl
+++ b/test/factor.jl
@@ -1,0 +1,94 @@
+
+using Elemental, Test, Random
+Random.seed!(1)
+
+@testset "factor" begin
+  @testset "qr!" begin
+    N = 10 
+    M = 9
+    
+    A = rand(ComplexF64, N, M)
+    b = rand(ComplexF64, N)
+    
+    A1 = Elemental.Matrix(ComplexF64)
+    Elemental.resize!(A1, size(A)...);
+    A1 .= A
+    
+    qrA = Elemental._qr!(A1)
+    
+    b0 = Elemental.Matrix(ComplexF64)
+    
+    Elemental.resize!(b0, length(b), 1);
+    b0 .= b
+    
+    x = A \ b
+    #@show A'*A * x .- A' *b
+    x1 = Vector(Matrix(qrA \ b0)[:])
+    @test isapprox(x1, x)
+  end
+  @testset "lq!" begin
+    N = 9
+    M = 10
+    
+    A = rand(ComplexF64, N, M)
+    b = rand(ComplexF64, N)
+    
+    A1 = Elemental.Matrix(ComplexF64)
+    Elemental.resize!(A1, size(A)...);
+    A1 .= A
+    
+    lqA = Elemental._lq!(A1)
+    
+    b0 = Elemental.Matrix(ComplexF64)
+    
+    Elemental.resize!(b0, length(b), 1);
+    b0 .= b
+    
+    x = A \ b
+    #@show A'*A * x .- A' *b
+    x1 = Vector(Matrix(lqA \ b0)[:])
+    @test isapprox(x1, x)
+  end
+  @testset "lu!" begin
+    N = 10 
+    M = 10
+    
+    A = rand(ComplexF64, N, M)
+    b = rand(ComplexF64, N)
+    
+    A1 = Elemental.Matrix(ComplexF64)
+    Elemental.resize!(A1, size(A)...);
+    A1 .= A
+    
+    luA = Elemental._lu!(A1)
+    
+    b0 = Elemental.Matrix(ComplexF64)
+    
+    Elemental.resize!(b0, length(b), 1);
+    b0 .= b
+    
+    x = A \ b
+    @show size(x)
+    #@show A'*A * x .- A' *b
+    x1 = Vector(Matrix(luA \ b0)[:])
+    @show size(x1)
+    @test isapprox(x1, x)
+  end
+end
+
+#A2 = Elemental.Matrix(ComplexF64)
+#Elemental.resize!(A2, size(A)...);
+#A2 .= A
+#b1 = Elemental.Matrix(ComplexF64)
+#Elemental.resize!(b1, length(b), 1);
+#b1 .= b
+#qrcp = Elemental._qrcp!(A2)
+#
+#x2 = Vector(Matrix(qrcp \ b1)[:])
+#@show x
+#y = real.(x2)
+#@show y
+#@test isapprox(x2, x)
+
+
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Elemental
 
 function runtests_mpirun()
     nprocs = min(4, Sys.CPU_THREADS)
-    testfiles = ["lav.jl", "lavdense.jl", "matrix.jl", "distmatrix.jl", "props.jl", "generic.jl", "spectral.jl", "tsvd.jl", "svd.jl"]
+    testfiles = ["lav.jl", "lavdense.jl", "matrix.jl", "distmatrix.jl", "props.jl", "generic.jl", "spectral.jl", "tsvd.jl", "svd.jl", "factor.jl"]
     nfail = 0
     @info "Running Elemental.jl tests"
     for f in testfiles

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,7 @@ using Elemental
 
 function runtests_mpirun()
     nprocs = min(4, Sys.CPU_THREADS)
-    testfiles = ["lav.jl", "lavdense.jl", "matrix.jl", "distmatrix.jl", "props.jl", "generic.jl", "spectral.jl", "tsvd.jl", "svd.jl", "factor.jl"]
+    testfiles = ["lav.jl", "lavdense.jl", "matrix.jl", "distmatrix.jl", "props.jl", "generic.jl", "spectral.jl", "tsvd.jl", "svd.jl"]
     nfail = 0
     @info "Running Elemental.jl tests"
     for f in testfiles


### PR DESCRIPTION
I'd like to be able to use the in-place versions of `Cholesky`, `LU`, `QR` and `LQ` factorisations available in the C++ library. This is a work-in-progress PR to enable this functionality. As of now, the following are tested and pass:
 - Distributed and serial, pivot-less calls to:
   - [x] `QR`
   - [x] `LQ` 
   - [x] `LU`
   - [x] `Cholesky`

Also:
 - [x] Format the code so that it's the same as the rest.